### PR TITLE
support of secrets manager secrets

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -68,7 +68,10 @@ variable "parameter_paths_write" {
 }
 
 variable "secrets" {
-  type    = list(string)
+  type = list(object({
+    name      = string
+    valueFrom = string
+  }))
   default = []
 }
 


### PR DESCRIPTION
Secrets manager's secrets can be used in ECS via the secrets section in the container definition.

Introduced changes:
* secrets type check is strict because it's passed into the container definition.
* permissions to access the secret and KMS used to encrypt the secret is added to the permission automatically.
